### PR TITLE
verify session consistency between email verification and user registration

### DIFF
--- a/user/src/main/java/cm/twentysix/user/controller/EmailAuthController.java
+++ b/user/src/main/java/cm/twentysix/user/controller/EmailAuthController.java
@@ -1,7 +1,10 @@
 package cm.twentysix.user.controller;
 
 import cm.twentysix.user.controller.dto.SendAuthEmailForm;
+import cm.twentysix.user.controller.dto.SendAuthEmailResponse;
 import cm.twentysix.user.service.EmailAuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,8 +17,10 @@ public class EmailAuthController {
     private final EmailAuthService emailAuthService;
 
     @PostMapping
-    public ResponseEntity<Void> sendAuthEmail(@RequestBody @Valid SendAuthEmailForm form) {
-        emailAuthService.sendAuthEmail(form);
+    public ResponseEntity<Void> sendAuthEmail(@RequestBody @Valid SendAuthEmailForm form, HttpServletRequest request) {
+        SendAuthEmailResponse response = emailAuthService.sendAuthEmail(form);
+        HttpSession httpSession = request.getSession();
+        httpSession.setAttribute("SESSION_ID", response.sessionId());
         return ResponseEntity.ok().build();
     }
 

--- a/user/src/main/java/cm/twentysix/user/controller/SignUpController.java
+++ b/user/src/main/java/cm/twentysix/user/controller/SignUpController.java
@@ -2,13 +2,13 @@ package cm.twentysix.user.controller;
 
 import cm.twentysix.user.controller.dto.SignUpForm;
 import cm.twentysix.user.service.SignUpService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,8 +17,9 @@ public class SignUpController {
     private final SignUpService signUpService;
 
     @PostMapping
-    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpForm form) {
-        signUpService.signUp(form);
+    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpForm form, HttpServletRequest request) {
+        String sessionId = (String) request.getSession().getAttribute("SESSION_ID");
+        signUpService.signUp(form, Optional.of(sessionId));
         return ResponseEntity.ok().build();
     }
 

--- a/user/src/main/java/cm/twentysix/user/controller/dto/SendAuthEmailResponse.java
+++ b/user/src/main/java/cm/twentysix/user/controller/dto/SendAuthEmailResponse.java
@@ -1,0 +1,9 @@
+package cm.twentysix.user.controller.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SendAuthEmailResponse(
+        String sessionId
+) {
+}

--- a/user/src/main/java/cm/twentysix/user/domain/model/EmailAuth.java
+++ b/user/src/main/java/cm/twentysix/user/domain/model/EmailAuth.java
@@ -6,14 +6,17 @@ import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
+import java.util.UUID;
+
 @Getter
 @Builder
-@RedisHash(value = "email-auths", timeToLive = 60 * 60 * 3)
+@RedisHash(value = "email-auths", timeToLive = 60 * 60 * 30)
 public class EmailAuth {
     @Id
     private String email;
     private String code;
     private boolean isVerified;
+    private String sessionId;
 
     public void verify() {
         this.isVerified = true;
@@ -24,6 +27,7 @@ public class EmailAuth {
                 .email(email)
                 .code(code)
                 .isVerified(false)
+                .sessionId(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/user/src/main/java/cm/twentysix/user/exception/Error.java
+++ b/user/src/main/java/cm/twentysix/user/exception/Error.java
@@ -11,6 +11,7 @@ public enum Error {
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 이메일이 존재하지 않습니다."),
     ALREADY_REGISTER_EMAIL(HttpStatus.FORBIDDEN, "이미 가입한 이메일입니다."),
     NOT_VERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "인증받지 않은 이메일입니다."),
+    NOT_VALID_REQUEST(HttpStatus.UNAUTHORIZED, "인증받지 않은 접근입니다."),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "패스워드가 다릅니다."),
     REQUEST_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "요청 데이터의 형식을 확인해주세요.");
     public final HttpStatus httpStatus;

--- a/user/src/test/java/cm/twentysix/user/controller/EmailAuthControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/EmailAuthControllerTest.java
@@ -1,6 +1,7 @@
 package cm.twentysix.user.controller;
 
 import cm.twentysix.user.controller.dto.SendAuthEmailForm;
+import cm.twentysix.user.controller.dto.SendAuthEmailResponse;
 import cm.twentysix.user.service.EmailAuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -33,7 +36,7 @@ class EmailAuthControllerTest {
     @DisplayName("인증 메일 발송_성공")
     void sendAuthEmail_success() throws Exception {
         SendAuthEmailForm form = new SendAuthEmailForm("abcde@naver.com");
-        emailAuthService.sendAuthEmail(form);
+        given(emailAuthService.sendAuthEmail(any())).willReturn(new SendAuthEmailResponse("randomuid"));
         mockMvc.perform(post("/users/email-auths")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(form)

--- a/user/src/test/java/cm/twentysix/user/controller/SignUpControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/SignUpControllerTest.java
@@ -2,7 +2,6 @@ package cm.twentysix.user.controller;
 
 import cm.twentysix.user.controller.dto.SignUpForm;
 import cm.twentysix.user.service.SignUpService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,10 +35,10 @@ class SignUpControllerTest {
         //given
         SignUpForm form = new SignUpForm("abcde@gmail.com", "Qwerty!@1", "010-1111-1111", "송송", "서울 특별시 성북구 보문로 23", "11111");
         //when
-        signUpService.signUp(form);
         //then
         mockMvc.perform(post("/users/signup")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .sessionAttr("SESSION_ID", "hihihiih")
                         .content(objectMapper.writeValueAsString(form)
                                 .getBytes(StandardCharsets.UTF_8)))
                 .andDo(print())
@@ -52,9 +51,9 @@ class SignUpControllerTest {
         //given
         SignUpForm form = new SignUpForm("abcdegmail.com", "Qwerty!@", "01011111111", "송", "서울 특별시", "1234");
         //when
-        signUpService.signUp(form);
         //then
         mockMvc.perform(post("/users/signup")
+                        .sessionAttr("SESSION_ID", "hihihiih")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(form)
                                 .getBytes(StandardCharsets.UTF_8)))

--- a/user/src/test/java/cm/twentysix/user/service/EmailAuthServiceTest.java
+++ b/user/src/test/java/cm/twentysix/user/service/EmailAuthServiceTest.java
@@ -5,6 +5,7 @@ import cm.twentysix.user.client.dto.SendMailForm;
 import cm.twentysix.user.constant.MailContent;
 import cm.twentysix.user.constant.MailSender;
 import cm.twentysix.user.controller.dto.SendAuthEmailForm;
+import cm.twentysix.user.controller.dto.SendAuthEmailResponse;
 import cm.twentysix.user.domain.model.EmailAuth;
 import cm.twentysix.user.domain.repository.EmailAuthRedisRepository;
 import cm.twentysix.user.domain.repository.UserRepository;
@@ -56,8 +57,12 @@ class EmailAuthServiceTest {
         SendAuthEmailForm form = new SendAuthEmailForm("abcde@gmail.com");
         given(cipherManager.encrypt(anyString())).willReturn("cipherManagerEncrypted");
         given(userRepository.existsByEmail(anyString())).willReturn(false);
+        given(emailAuthRepository.save(any())).willReturn(EmailAuth.builder()
+                .email("abcde@gmail.com")
+                .sessionId("sessionId")
+                .build());
         //when
-        emailAuthService.sendAuthEmail(form);
+        SendAuthEmailResponse response = emailAuthService.sendAuthEmail(form);
         //then
         ArgumentCaptor<EmailAuth> authCaptor = ArgumentCaptor.forClass(EmailAuth.class);
         verify(emailAuthRepository, times(1)).save(authCaptor.capture());
@@ -72,6 +77,8 @@ class EmailAuthServiceTest {
         assertEquals(sentMail.getFrom(), MailSender.AUTH.getEmailFrom());
         assertEquals(sentMail.getTo(), form.email());
         assertEquals(sentMail.getSubject(), MailContent.EMAIL_VERIFY.title);
+
+        assertEquals(response.sessionId(), "sessionId");
     }
 
     @Test

--- a/user/src/test/java/cm/twentysix/user/service/SignUpServiceTest.java
+++ b/user/src/test/java/cm/twentysix/user/service/SignUpServiceTest.java
@@ -61,11 +61,12 @@ class SignUpServiceTest {
         given(emailAuthRedisRepository.findById(anyString()))
                 .willReturn(Optional.of(EmailAuth.builder()
                         .email("abcde@gmail.com")
+                        .sessionId("anysessionId")
                         .code("longlongcode").isVerified(true).build()));
         given(passwordEncoder.encode(anyString())).willReturn("passwordEncoderEncrypt");
         given(userRepository.save(any())).willReturn(mockUser);
         //when
-        signUpService.signUp(form);
+        signUpService.signUp(form, Optional.of("anysessionId"));
         //then
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository, times(1)).save(userCaptor.capture());
@@ -91,7 +92,7 @@ class SignUpServiceTest {
         given(cipherManager.encrypt(anyString())).willReturn("cipherManagerEncrypt");
         given(userRepository.existsByEmail(anyString())).willReturn(true);
         //when
-        UserException e = assertThrows(UserException.class, () -> signUpService.signUp(form));
+        UserException e = assertThrows(UserException.class, () -> signUpService.signUp(form, Optional.of("anysessionId")));
         //then
         assertEquals(Error.ALREADY_REGISTER_EMAIL, e.getError());
     }
@@ -106,9 +107,10 @@ class SignUpServiceTest {
         given(emailAuthRedisRepository.findById(anyString()))
                 .willReturn(Optional.of(EmailAuth.builder()
                         .email("abcde@gmail.com")
+                        .sessionId("anysessionId")
                         .code("longlongcode").isVerified(false).build()));
         //when
-        EmailAuthException e = assertThrows(EmailAuthException.class, () -> signUpService.signUp(form));
+        EmailAuthException e = assertThrows(EmailAuthException.class, () -> signUpService.signUp(form, Optional.of("anysessionId")));
         //then
         assertEquals(Error.NOT_VERIFIED_EMAIL, e.getError());
     }
@@ -123,7 +125,7 @@ class SignUpServiceTest {
         given(emailAuthRedisRepository.findById(anyString()))
                 .willReturn(Optional.empty());
         //when
-        EmailAuthException e = assertThrows(EmailAuthException.class, () -> signUpService.signUp(form));
+        EmailAuthException e = assertThrows(EmailAuthException.class, () -> signUpService.signUp(form, Optional.of("anysessionId")));
         //then
         assertEquals(Error.NOT_VERIFIED_EMAIL, e.getError());
     }


### PR DESCRIPTION
## 🔎 PR Description
- Close #9 
> Check if the session is the same during email verification and user registration to enhance security

## 🔑 Key Changes
- add session id in email auth data
- check session id when user sign up

## 📢 To Reviewers