### PR TITLE
Updated to require input of purchase availability time during creation or modification

### DIFF
--- a/gateway/src/main/java/cm/twentysix/gateway/security/SecurityConfig.java
+++ b/gateway/src/main/java/cm/twentysix/gateway/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package cm.twentysix.gateway.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
@@ -33,6 +34,10 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
                 .authorizeExchange(authorizeExchangeSpec ->
                         authorizeExchangeSpec.pathMatchers("/users/email-auths/**", "/users/signup", "/users/login").permitAll()
+                                .pathMatchers(HttpMethod.GET, "/products/**").permitAll()
+                                .pathMatchers(HttpMethod.POST, "/products/**", "/brands/**").hasAnyAuthority("SELLER")
+                                .pathMatchers(HttpMethod.PUT, "/products/**", "/brands/**").hasAnyAuthority("SELLER")
+                                .pathMatchers(HttpMethod.DELETE, "/products/**", "/brands/**").hasAnyAuthority("SELLER")
                                 .anyExchange().hasAnyAuthority("SELLER", "USER"))
                 .build();
     }

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.hibernate:hibernate-validator:8.0.1.Final'
 }
 
 dependencyManagement {

--- a/product/src/main/java/cm/twentysix/product/domain/model/Product.java
+++ b/product/src/main/java/cm/twentysix/product/domain/model/Product.java
@@ -37,9 +37,10 @@ public class Product extends BaseTimeDocument {
     private ProductBrand productBrand;
     private Long userId;
     private boolean isDeleted;
+    private LocalDateTime orderingOpensAt;
 
     @Builder
-    public Product(String thumbnailPath, String bodyImagePath, Integer price, Integer discount, String name, Integer quantity, Integer deliveryFee, LocalDateTime lastModifiedAt, List<CategoryInfo> categories, Set<Long> likes, ProductBrand productBrand, Long userId, boolean isDeleted, ProductInfo productInfo) {
+    public Product(String thumbnailPath, String bodyImagePath, Integer price, Integer discount, String name, Integer quantity, Integer deliveryFee, LocalDateTime lastModifiedAt, List<CategoryInfo> categories, Set<Long> likes, ProductBrand productBrand, Long userId, boolean isDeleted, ProductInfo productInfo, LocalDateTime orderingOpensAt) {
         this.thumbnailPath = thumbnailPath;
         this.bodyImagePath = bodyImagePath;
         this.price = price;
@@ -54,6 +55,7 @@ public class Product extends BaseTimeDocument {
         this.productBrand = productBrand;
         this.userId = userId;
         this.isDeleted = isDeleted;
+        this.orderingOpensAt = orderingOpensAt;
     }
 
     public static Product of(CreateProductForm form, BrandProto.BrandResponse brand, Long userId, List<CategoryInfoDto> categoryInfoDtos, String thumbnailPath, String bodyImagePath) {
@@ -72,6 +74,7 @@ public class Product extends BaseTimeDocument {
                 .userId(userId)
                 .thumbnailPath(thumbnailPath)
                 .bodyImagePath(bodyImagePath)
+                .orderingOpensAt(form.parseOrderingOpensAt())
                 .build();
     }
 
@@ -88,6 +91,7 @@ public class Product extends BaseTimeDocument {
         this.userId = userId;
         this.thumbnailPath = thumbnailPath;
         this.bodyImagePath = bodyImagePath;
+        this.orderingOpensAt = form.parseOrderingOpensAt();
     }
 
     public void delete() {

--- a/product/src/main/java/cm/twentysix/product/dto/CreateProductForm.java
+++ b/product/src/main/java/cm/twentysix/product/dto/CreateProductForm.java
@@ -1,6 +1,10 @@
 package cm.twentysix.product.dto;
 
+import cm.twentysix.product.util.validator.NullOrAfterDateTime;
 import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 public record CreateProductForm(
         @NotNull(message = "브랜드 id는 비어 있을 수 없습니다.")
@@ -26,6 +30,17 @@ public record CreateProductForm(
         Integer discount,
         @Min(value = 0, message = "기본 배송비는 0원 이상입니다.")
         @Max(value = 100000, message = "기본 배송비는 10000원 이하입니다.")
-        Integer deliveryFee
+        Integer deliveryFee,
+        @NullOrAfterDateTime(message = "과거이거나 datetime 형식이 아닙니다.")
+        String orderingOpensAt
 ) {
+    public LocalDateTime parseOrderingOpensAt() {
+        if (orderingOpensAt == null)
+            return LocalDateTime.now();
+        try {
+            return LocalDateTime.parse(orderingOpensAt);
+        } catch (DateTimeParseException e) {
+            return LocalDateTime.now();
+        }
+    }
 }

--- a/product/src/main/java/cm/twentysix/product/dto/UpdateProductForm.java
+++ b/product/src/main/java/cm/twentysix/product/dto/UpdateProductForm.java
@@ -1,9 +1,13 @@
 package cm.twentysix.product.dto;
 
+import cm.twentysix.product.util.validator.NullOrAfterDateTime;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 public record UpdateProductForm(
         @NotBlank(message = "카테고리 id는 비어 있을 수 없습니다.")
@@ -27,6 +31,17 @@ public record UpdateProductForm(
         Integer discount,
         @Min(value = 0, message = "기본 배송비는 0원 이상입니다.")
         @Max(value = 100000, message = "기본 배송비는 10000원 이하입니다.")
-        Integer deliveryFee
+        Integer deliveryFee,
+        @NullOrAfterDateTime(message = "과거이거나 datetime 형식이 아닙니다.")
+        String orderingOpensAt
 ) {
+    public LocalDateTime parseOrderingOpensAt() {
+        if (orderingOpensAt == null)
+            return LocalDateTime.now();
+        try {
+            return LocalDateTime.parse(orderingOpensAt);
+        } catch (DateTimeParseException e) {
+            return LocalDateTime.now();
+        }
+    }
 }

--- a/product/src/main/java/cm/twentysix/product/util/validator/NullOrAfterDateTime.java
+++ b/product/src/main/java/cm/twentysix/product/util/validator/NullOrAfterDateTime.java
@@ -1,0 +1,21 @@
+package cm.twentysix.product.util.validator;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NullOrAfterDateTimeValidator.class)
+public @interface NullOrAfterDateTime {
+    String message() default "invalid datetime format";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/product/src/main/java/cm/twentysix/product/util/validator/NullOrAfterDateTimeValidator.java
+++ b/product/src/main/java/cm/twentysix/product/util/validator/NullOrAfterDateTimeValidator.java
@@ -1,0 +1,30 @@
+package cm.twentysix.product.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class NullOrAfterDateTimeValidator implements ConstraintValidator<NullOrAfterDateTime, String> {
+    private DateTimeFormatter dateTimeFormatter;
+
+    @Override
+    public void initialize(NullOrAfterDateTime constraintAnnotation) {
+        dateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME;
+    }
+
+    @Override
+    public boolean isValid(String string, ConstraintValidatorContext constraintValidatorContext) {
+        if (string == null) {
+            return true;
+        }
+        try {
+            return LocalDateTime.parse(string).isAfter(LocalDateTime.now());
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+
+}

--- a/product/src/test/java/cm/twentysix/product/controller/ProductControllerTest.java
+++ b/product/src/test/java/cm/twentysix/product/controller/ProductControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -31,10 +33,11 @@ class ProductControllerTest {
     @MockBean
     private ProductService productService;
 
+
     @Test
     void createProduct_success() throws Exception {
         //given
-        CreateProductForm form = new CreateProductForm(1L, "123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        CreateProductForm form = new CreateProductForm(1L, "123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, null);
         //when
         //then
         mockMvc.perform(multipart(HttpMethod.POST, "/products")
@@ -54,7 +57,7 @@ class ProductControllerTest {
     @Test
     void createProduct_fail() throws Exception {
         //given
-        CreateProductForm form = new CreateProductForm(null, "      ", "", "In a @WebMvcTest setup, if you encounter errors related to unnecessary bean dependencies, it often means there might be some implicit dependencies or configurations that the test context is trying to resolve. This usually occurs when the test context is expecting certain beans that aren't explicitly mocked or provided. It is essential to ensure that only the necessary beans for the controller under test are included and correctly mocked to avoid such dependency issues.", "very long long long long long country nameeeee", "AS센터", -1, -1, 101, 100001);
+        CreateProductForm form = new CreateProductForm(null, "      ", "", "In a @WebMvcTest setup, if you encounter errors related to unnecessary bean dependencies, it often means there might be some implicit dependencies or configurations that the test context is trying to resolve. This usually occurs when the test context is expecting certain beans that aren't explicitly mocked or provided. It is essential to ensure that only the necessary beans for the controller under test are included and correctly mocked to avoid such dependency issues.", "very long long long long long country nameeeee", "AS센터", -1, -1, 101, 100001, "1234");
         //when
         //then
         mockMvc.perform(multipart(HttpMethod.POST, "/products")
@@ -78,14 +81,15 @@ class ProductControllerTest {
                         jsonPath("$.message.price").value("가격은 0원 이상입니다."),
                         jsonPath("$.message.quantity").value("재고는 0개 이상입니다."),
                         jsonPath("$.message.discount").value("할인율은 100 퍼센트 이하입니다."),
-                        jsonPath("$.message.deliveryFee").value("기본 배송비는 10000원 이하입니다.")
+                        jsonPath("$.message.deliveryFee").value("기본 배송비는 10000원 이하입니다."),
+                        jsonPath("$.message.orderingOpensAt").value("과거이거나 datetime 형식이 아닙니다.")
                 );
     }
 
     @Test
     void updateProduct_success() throws Exception {
         //given
-        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, LocalDateTime.MAX.toString());
         //when
         //then
         mockMvc.perform(multipart(HttpMethod.PUT, "/products/{productId}", "abcdefkghaskfldlm123")
@@ -105,7 +109,7 @@ class ProductControllerTest {
     @Test
     void updateProduct_fail() throws Exception {
         //given
-        UpdateProductForm form = new UpdateProductForm("      ", "", "In a @WebMvcTest setup, if you encounter errors related to unnecessary bean dependencies, it often means there might be some implicit dependencies or configurations that the test context is trying to resolve. This usually occurs when the test context is expecting certain beans that aren't explicitly mocked or provided. It is essential to ensure that only the necessary beans for the controller under test are included and correctly mocked to avoid such dependency issues.", "very long long long long long country nameeeee", "AS센터", -1, -1, 101, 100001);
+        UpdateProductForm form = new UpdateProductForm("      ", "", "In a @WebMvcTest setup, if you encounter errors related to unnecessary bean dependencies, it often means there might be some implicit dependencies or configurations that the test context is trying to resolve. This usually occurs when the test context is expecting certain beans that aren't explicitly mocked or provided. It is essential to ensure that only the necessary beans for the controller under test are included and correctly mocked to avoid such dependency issues.", "very long long long long long country nameeeee", "AS센터", -1, -1, 101, 100001, "1234");
         //when
         //then
         mockMvc.perform(multipart(HttpMethod.PUT, "/products/{productId}", "abcdefkghaskfldlm123")
@@ -128,7 +132,8 @@ class ProductControllerTest {
                         jsonPath("$.message.price").value("가격은 0원 이상입니다."),
                         jsonPath("$.message.quantity").value("재고는 0개 이상입니다."),
                         jsonPath("$.message.discount").value("할인율은 100 퍼센트 이하입니다."),
-                        jsonPath("$.message.deliveryFee").value("기본 배송비는 10000원 이하입니다.")
+                        jsonPath("$.message.deliveryFee").value("기본 배송비는 10000원 이하입니다."),
+                        jsonPath("$.message.orderingOpensAt").value("과거이거나 datetime 형식이 아닙니다.")
                 );
     }
 

--- a/product/src/test/java/cm/twentysix/product/service/ProductServiceTest.java
+++ b/product/src/test/java/cm/twentysix/product/service/ProductServiceTest.java
@@ -67,12 +67,14 @@ class ProductServiceTest {
                     .build()
     );
 
+    String orderingBeginAt = LocalDateTime.of(2024,12,12,12,12,12).toString();
+
     @Test
     void createProduct_success() {
         //given
         MultipartFile thumbnail = new MockMultipartFile("abc.jpg", "abcd".getBytes());
         MultipartFile descriptionImage = new MockMultipartFile("abc.jpg", "abcd".getBytes());
-        CreateProductForm form = new CreateProductForm(1L, "123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        CreateProductForm form = new CreateProductForm(1L, "123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, null);
         given(categoryService.retrieveBelongingCategories(form.categoryId())).willReturn(categoryInfoDtos);
         given(brandGrpcClient.getBrandInfo(anyLong())).willReturn(BrandProto.BrandResponse.newBuilder().setId(1L).setName("뉴발란스").setUserId(1L).build());
         given(fileStorageClient.upload((MultipartFile) any(), any())).willReturn("afsdfasfsdafasd.jpg");
@@ -99,6 +101,7 @@ class ProductServiceTest {
         assertFalse(product.isDeleted());
         assertEquals(product.getProductBrand().getId(), 1L);
         assertEquals(product.getProductBrand().getName(), "뉴발란스");
+        assertTrue(LocalDateTime.now().isAfter(product.getOrderingOpensAt()));
     }
 
     @Test
@@ -106,7 +109,7 @@ class ProductServiceTest {
         //given
         MultipartFile thumbnail = new MockMultipartFile("abc.jpg", "abcd".getBytes());
         MultipartFile descriptionImage = new MockMultipartFile("abc.jpg", "abcd".getBytes());
-        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, orderingBeginAt);
         given(brandGrpcClient.getBrandInfo(anyLong())).willReturn(BrandProto.BrandResponse.newBuilder().setId(1L).setName("뉴발란스").setUserId(1L).build());
         Product product = Product.builder()
                 .thumbnailPath("12345.jpg")
@@ -151,6 +154,7 @@ class ProductServiceTest {
         assertFalse(product.isDeleted());
         assertEquals(product.getProductBrand().getId(), 1L);
         assertEquals(product.getProductBrand().getName(), "뉴발란스");
+        assertEquals(orderingBeginAt, product.getOrderingOpensAt().toString());
     }
 
     @Test
@@ -158,7 +162,7 @@ class ProductServiceTest {
         //given
         MultipartFile thumbnail = new MockMultipartFile("abc.jpg", "abcd".getBytes());
         MultipartFile descriptionImage = new MockMultipartFile("abc.jpg", "abcd".getBytes());
-        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, orderingBeginAt);
         given(productRepository.findById(anyString())).willReturn(Optional.empty());
 
         //when
@@ -172,7 +176,7 @@ class ProductServiceTest {
         //given
         MultipartFile thumbnail = new MockMultipartFile("abc.jpg", "abcd".getBytes());
         MultipartFile descriptionImage = new MockMultipartFile("abc.jpg", "abcd".getBytes());
-        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, orderingBeginAt);
         Product product = Product.builder()
                 .thumbnailPath("12345.jpg")
                 .bodyImagePath("78910.jpg")
@@ -205,7 +209,7 @@ class ProductServiceTest {
         //given
         MultipartFile thumbnail = new MockMultipartFile("abc.jpg", "abcd".getBytes());
         MultipartFile descriptionImage = new MockMultipartFile("abc.jpg", "abcd".getBytes());
-        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500);
+        UpdateProductForm form = new UpdateProductForm("123edsf3fdsfdsa3560fdg", "NBGCEFW701 / 글로시 리본 더플백 (VIORET)", "(주)이랜드월드 뉴발란스 사업부", "중국", "뉴발란스 고객 상담실 (080-999-0456)", 69900, 200, 0, 2500, orderingBeginAt);
         Product product = Product.builder()
                 .thumbnailPath("12345.jpg")
                 .bodyImagePath("78910.jpg")


### PR DESCRIPTION
## 🔎 PR Description
- Close #50 
> Added a purchase availability time field to the product entity

## 🔑 Key Changes
- Updated to require input of purchase availability time during creation or modification

## 📢 To Reviewers