### PR TITLE
Apply Global Caching to ProductItemResponse

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   api-gateway:
     build:
-      context: ./gateway
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./gateway/Dockerfile-test
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       REDIS_HOST: ${REDIS_HOST}
@@ -21,8 +21,8 @@ services:
 
   brand-service:
     build:
-      context: ./brand
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./brand/Dockerfile-test
     ports:
       - "8082:8082"
     environment:
@@ -32,12 +32,12 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}
     networks:
-      - app-network
+      - ts-network
 
   user-service:
     build:
-      context: ./user
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./user/Dockerfile-test
     ports:
       - "8081:8081"
     environment:
@@ -49,12 +49,12 @@ services:
       MAILGUN_KEY: ${MAILGUN_KEY}
       KAFKA_BROKERS: ${KAFKA_BROKERS}
     networks:
-      - app-network
+      - ts-network
 
   product-service:
     build:
-      context: ./product
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./product/Dockerfile-test
     ports:
       - "8083:8083"
     environment:
@@ -64,12 +64,12 @@ services:
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}
     networks:
-      - app-network
+      - ts-network
 
   payment-service:
     build:
-      context: ./payment
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./payment/Dockerfile-test
     ports:
       - "8085:8085"
     environment:
@@ -78,12 +78,12 @@ services:
       KAFKA_BROKERS: ${KAFKA_BROKERS}
       TOSS_PAYMENT_SECRET: ${TOSS_PAYMENT_SECRET}
     networks:
-      - app-network
+      - ts-network
 
   order-service:
     build:
-      context: ./order
-      dockerfile: Dockerfile-test
+      context: .
+      dockerfile: ./order/Dockerfile-test
     ports:
       - "8084:8084"
     environment:
@@ -93,9 +93,9 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       REDIS_HOST: ${REDIS_HOST}
     networks:
-      - app-network
+      - ts-network
 
 networks:
-  app-network:
-    driver: bridge
+  ts-network:
+    external: true
 

--- a/order/src/main/java/cm/twentysix/order/cache/GlobalCacheKey.java
+++ b/order/src/main/java/cm/twentysix/order/cache/GlobalCacheKey.java
@@ -1,0 +1,14 @@
+package cm.twentysix.order.cache;
+
+import lombok.AllArgsConstructor;
+
+import java.time.Duration;
+
+@AllArgsConstructor
+public enum GlobalCacheKey {
+    PRODUCT(Duration.ofMinutes(10L))
+    ;
+
+    public final Duration duration;
+
+}

--- a/order/src/main/java/cm/twentysix/order/cache/GlobalCacheRepository.java
+++ b/order/src/main/java/cm/twentysix/order/cache/GlobalCacheRepository.java
@@ -1,0 +1,19 @@
+package cm.twentysix.order.cache;
+
+import java.time.Duration;
+
+public abstract class GlobalCacheRepository {
+    private final GlobalCacheKey globalCacheKey;
+
+    protected GlobalCacheRepository(GlobalCacheKey globalCacheKey) {
+        this.globalCacheKey = globalCacheKey;
+    }
+
+    String getCacheKey(String id) {
+        return globalCacheKey.name() + id;
+    }
+
+    Duration getCacheDuration() {
+        return globalCacheKey.duration;
+    }
+}

--- a/order/src/main/java/cm/twentysix/order/cache/ProductItemResponseGlobalCacheRepository.java
+++ b/order/src/main/java/cm/twentysix/order/cache/ProductItemResponseGlobalCacheRepository.java
@@ -1,0 +1,38 @@
+package cm.twentysix.order.cache;
+
+import cm.twentysix.ProductProto.ProductItemResponse;
+import cm.twentysix.order.client.RedisClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@Slf4j
+public class ProductItemResponseGlobalCacheRepository extends GlobalCacheRepository {
+    private final RedisClient<ProductItemResponse> redisClient;
+
+    protected ProductItemResponseGlobalCacheRepository(RedisClient<ProductItemResponse> redisClient) {
+        super(GlobalCacheKey.PRODUCT);
+        this.redisClient = redisClient;
+    }
+
+    public Map<String, ProductItemResponse> getAll(List<String> productIds) {
+        List<String> cacheKeys = productIds.stream().map(this::getCacheKey).toList();
+        List<ProductItemResponse> values = redisClient.getValues(cacheKeys);
+
+        if (values.isEmpty())
+            return new HashMap<>();
+        return values.stream()
+                .collect(Collectors.toMap(ProductItemResponse::getId, product -> product));
+    }
+
+    public Optional<ProductItemResponse> get(String productId) {
+        return Optional.ofNullable(redisClient.getValue(getCacheKey(productId)));
+    }
+
+}

--- a/order/src/main/java/cm/twentysix/order/client/RedisClient.java
+++ b/order/src/main/java/cm/twentysix/order/client/RedisClient.java
@@ -1,0 +1,22 @@
+package cm.twentysix.order.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class RedisClient<T> {
+    private final RedisTemplate<String, T> redisTemplate;
+
+    public List<T> getValues(List<String> keys) {
+        List<T> values = redisTemplate.opsForValue().multiGet(keys);
+        return values.stream().filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    public T getValue(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+}

--- a/order/src/main/java/cm/twentysix/order/config/CacheConfig.java
+++ b/order/src/main/java/cm/twentysix/order/config/CacheConfig.java
@@ -1,5 +1,7 @@
 package cm.twentysix.order.config;
 
+import cm.twentysix.ProductProto.ProductItemResponse;
+import cm.twentysix.order.client.RedisClient;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;

--- a/order/src/main/java/cm/twentysix/order/config/ProtobufRedisSerializer.java
+++ b/order/src/main/java/cm/twentysix/order/config/ProtobufRedisSerializer.java
@@ -1,0 +1,35 @@
+package cm.twentysix.order.config;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+public class ProtobufRedisSerializer<T extends Message> implements RedisSerializer<T> {
+    private final Parser<T> parser;
+
+    public ProtobufRedisSerializer(Parser<T> parser) {
+        this.parser = parser;
+    }
+
+
+    @Override
+    public byte[] serialize(T value) throws SerializationException {
+        if (value == null) {
+            return new byte[0];
+        }
+        return value.toByteArray();
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            return parser.parseFrom(bytes);
+        } catch (Exception e) {
+            throw new SerializationException("Failed to deserialize Protobuf message", e);
+        }
+    }
+}

--- a/order/src/main/java/cm/twentysix/order/exception/Error.java
+++ b/order/src/main/java/cm/twentysix/order/exception/Error.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum Error {
+    STOCK_SHORTAGE(HttpStatus.CONFLICT, "재고 부족으로 주문에 실패했습니다."),
     ORDER_CONTAIN_CLOSING_PRODUCT(HttpStatus.BAD_REQUEST, "구매 불가능한 상품이 포함되어 있습니다."),
     NOT_USERS_ORDER(HttpStatus.BAD_REQUEST, "유저의 주문이 아닙니다."),
     PROCESSING_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "처리 진행 중인 주문이 없습니다."),

--- a/order/src/main/java/cm/twentysix/order/exception/GlobalExceptionHandler.java
+++ b/order/src/main/java/cm/twentysix/order/exception/GlobalExceptionHandler.java
@@ -75,7 +75,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse<String>> handleException(Exception e) {
-        log.error(LOG_FORMAT, e.getClass().getSimpleName(), HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        log.error(LOG_FORMAT, e.getClass().getSimpleName(), HttpStatus.INTERNAL_SERVER_ERROR, e.getStackTrace());
         return ResponseEntity.internalServerError()
                 .body(new ExceptionResponse<>(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage()));
     }

--- a/order/src/main/proto/product.proto
+++ b/order/src/main/proto/product.proto
@@ -22,6 +22,7 @@ message ProductItemResponse {
   int32 price = 7;
   int32 discountedPrice = 8;
   string orderingOpensAt = 9;
+  int32 quantity = 10;
 }
 
 message ProductItemsRequest {

--- a/payment/src/main/java/cm/twentysix/payment/exception/Error.java
+++ b/payment/src/main/java/cm/twentysix/payment/exception/Error.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum Error {
+    CANCELLED_ORDER(HttpStatus.BAD_REQUEST, "Cancelled order"),
+    ALREADY_PAID_ORDER(HttpStatus.BAD_REQUEST, "Already paid order"),
     PAYMENT_FAILED(HttpStatus.PRECONDITION_FAILED, "Payment failed"),
     NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "해당하는 결제 건이 없습니다."),
     STOCK_SHORTAGE(HttpStatus.CONFLICT, "Order failed due to insufficient stock"),

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     testImplementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.hibernate:hibernate-validator:8.0.1.Final'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 dependencyManagement {

--- a/product/src/main/java/cm/twentysix/product/cache/GlobalCacheKey.java
+++ b/product/src/main/java/cm/twentysix/product/cache/GlobalCacheKey.java
@@ -1,0 +1,14 @@
+package cm.twentysix.product.cache;
+
+import lombok.AllArgsConstructor;
+
+import java.time.Duration;
+
+@AllArgsConstructor
+public enum GlobalCacheKey {
+    PRODUCT(Duration.ofMinutes(10L))
+    ;
+
+    public final Duration duration;
+
+}

--- a/product/src/main/java/cm/twentysix/product/cache/GlobalCacheRepository.java
+++ b/product/src/main/java/cm/twentysix/product/cache/GlobalCacheRepository.java
@@ -1,0 +1,19 @@
+package cm.twentysix.product.cache;
+
+import java.time.Duration;
+
+public abstract class GlobalCacheRepository {
+    private final GlobalCacheKey globalCacheKey;
+
+    protected GlobalCacheRepository(GlobalCacheKey globalCacheKey) {
+        this.globalCacheKey = globalCacheKey;
+    }
+
+    String getCacheKey(String id) {
+        return globalCacheKey.name() + id;
+    }
+
+    Duration getCacheDuration() {
+        return globalCacheKey.duration;
+    }
+}

--- a/product/src/main/java/cm/twentysix/product/cache/ProductItemResponseGlobalCacheRepository.java
+++ b/product/src/main/java/cm/twentysix/product/cache/ProductItemResponseGlobalCacheRepository.java
@@ -1,0 +1,46 @@
+package cm.twentysix.product.cache;
+
+import cm.twentysix.ProductProto.ProductItemResponse;
+import cm.twentysix.product.client.RedisClient;
+import cm.twentysix.product.domain.model.Product;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Repository
+public class ProductItemResponseGlobalCacheRepository extends GlobalCacheRepository {
+    private final RedisClient<ProductItemResponse> redisClient;
+
+    protected ProductItemResponseGlobalCacheRepository(RedisClient<ProductItemResponse> redisClient) {
+        super(GlobalCacheKey.PRODUCT);
+        this.redisClient = redisClient;
+    }
+
+    public void put(Product product) {
+        redisClient.addValue(getCacheKey(product.getId()), toProductItemResponse(product), getCacheDuration());
+    }
+
+    public void putAll(List<Product> products) {
+        Map<String, ProductItemResponse> keyValues =
+                products.stream().collect(Collectors.toMap(product -> getCacheKey(product.getId()), this::toProductItemResponse));
+        redisClient.addValues(keyValues, getCacheDuration());
+    }
+
+    private ProductItemResponse toProductItemResponse(Product product) {
+        return ProductItemResponse.newBuilder()
+                .setId(product.getId())
+                .setBrandId(product.getProductBrand().getId())
+                .setName(product.getName())
+                .setThumbnail(product.getThumbnailPath())
+                .setDiscount(product.getDiscount())
+                .setPrice(product.getPrice())
+                .setDiscountedPrice(product.getDiscountedPrice())
+                .setQuantity(product.getQuantity())
+                .setBrandName(product.getProductBrand().getName())
+                .setOrderingOpensAt(product.getOrderingOpensAt().toString())
+                .build();
+    }
+
+}

--- a/product/src/main/java/cm/twentysix/product/client/RedisClient.java
+++ b/product/src/main/java/cm/twentysix/product/client/RedisClient.java
@@ -1,0 +1,44 @@
+package cm.twentysix.product.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+public class RedisClient<T> {
+    private final RedisTemplate<String, T> redisTemplate;
+    private final RedisSerializer<String> keySerializer;
+    private final RedisSerializer valueSerializer;
+
+    public RedisClient(RedisTemplate<String, T> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.keySerializer = new StringRedisSerializer();
+        this.valueSerializer = new GenericJackson2JsonRedisSerializer();
+
+    }
+
+    public void addValues(Map<String, T> keyValueMap, Duration duration) {
+        try {
+            redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+                keyValueMap.forEach((k, v) -> redisTemplate.opsForValue().set(k, v, duration));
+                return null;
+            });
+        } catch (Exception e) {
+            log.error(e.toString());
+        }
+    }
+
+    public void addValue(String key, T value, Duration duration) {
+        redisTemplate.opsForValue().set(key, value, duration);
+    }
+
+}

--- a/product/src/main/java/cm/twentysix/product/config/ProtobufRedisSerializer.java
+++ b/product/src/main/java/cm/twentysix/product/config/ProtobufRedisSerializer.java
@@ -1,0 +1,34 @@
+package cm.twentysix.product.config;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+public class ProtobufRedisSerializer<T extends Message> implements RedisSerializer<T> {
+    private final Parser<T> parser;
+
+    public ProtobufRedisSerializer(Parser<T> parser) {
+        this.parser = parser;
+    }
+
+    @Override
+    public byte[] serialize(T value) throws SerializationException {
+        if (value == null) {
+            return new byte[0];
+        }
+        return value.toByteArray();
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            return parser.parseFrom(bytes);
+        } catch (Exception e) {
+            throw new SerializationException("Failed to deserialize Protobuf message", e);
+        }
+    }
+}

--- a/product/src/main/java/cm/twentysix/product/config/RedisConfig.java
+++ b/product/src/main/java/cm/twentysix/product/config/RedisConfig.java
@@ -1,17 +1,14 @@
-package cm.twentysix.order.config;
+package cm.twentysix.product.config;
 
 import cm.twentysix.ProductProto.ProductItemResponse;
-import cm.twentysix.order.client.RedisClient;
+import cm.twentysix.product.client.RedisClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 public class RedisConfig {
     @Bean
     public RedisTemplate<String, ProductItemResponse> productItemResponseRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
@@ -26,4 +23,5 @@ public class RedisConfig {
     public RedisClient<ProductItemResponse> productItemResponseRedisClient(RedisTemplate<String, ProductItemResponse> redisTemplate) {
         return new RedisClient<>(redisTemplate);
     }
+
 }

--- a/product/src/main/java/cm/twentysix/product/service/ProductGrpcService.java
+++ b/product/src/main/java/cm/twentysix/product/service/ProductGrpcService.java
@@ -1,9 +1,9 @@
 package cm.twentysix.product.service;
 
 import cm.twentysix.ProductServiceGrpc;
+import cm.twentysix.product.cache.ProductItemResponseGlobalCacheRepository;
 import cm.twentysix.product.domain.model.Product;
 import cm.twentysix.product.domain.repository.ProductRepository;
-import cm.twentysix.product.exception.Error;
 import cm.twentysix.product.exception.ProductException;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -14,20 +14,24 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static cm.twentysix.ProductProto.*;
+import static cm.twentysix.product.exception.Error.PRODUCT_NOT_FOUND;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBase {
     private final ProductRepository productRepository;
+    private final ProductItemResponseGlobalCacheRepository productItemResponseGlobalCacheRepository;
 
     @Override
     public void getProductItem(ProductItemRequest request, StreamObserver<ProductItemResponse> responseObserver) {
         try {
             Product product = productRepository.findByIdAndIsDeletedFalse(request.getId())
-                    .orElseThrow(() -> new ProductException(Error.PRODUCT_NOT_FOUND));
+                    .orElseThrow(() -> new ProductException(PRODUCT_NOT_FOUND));
+            CompletableFuture.runAsync(() -> productItemResponseGlobalCacheRepository.put(product));
             ProductItemResponse response = ProductItemResponse.newBuilder()
                     .setId(product.getId())
                     .setBrandId(product.getProductBrand().getId())
@@ -37,6 +41,7 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
                     .setPrice(product.getPrice())
                     .setDiscountedPrice(product.getDiscountedPrice())
                     .setBrandName(product.getProductBrand().getName())
+                    .setQuantity(product.getQuantity())
                     .setOrderingOpensAt(product.getOrderingOpensAt().toString())
                     .build();
             responseObserver.onNext(response);
@@ -54,21 +59,25 @@ public class ProductGrpcService extends ProductServiceGrpc.ProductServiceImplBas
     }
 
     @Override
-    public void getProductItems(ProductItemsRequest request, StreamObserver<ProductItemsResponse> responseObserver) {
+    public void getProductItems(ProductItemsRequest request, StreamObserver<ProductItemsResponse> responseObserver) throws ProductException {
         try {
-            List<ProductItemResponse> products = productRepository.findByIdInAndIsDeletedFalse(new HashSet<>(request.getIdsList()))
-                    .stream().map(product -> ProductItemResponse.newBuilder()
-                            .setId(product.getId())
-                            .setBrandId(product.getProductBrand().getId())
-                            .setName(product.getName())
-                            .setThumbnail(product.getThumbnailPath())
-                            .setDiscount(product.getDiscount())
-                            .setPrice(product.getPrice())
-                            .setDiscountedPrice(product.getDiscountedPrice())
-                            .setBrandName(product.getProductBrand().getName())
-                            .setOrderingOpensAt(product.getOrderingOpensAt().toString())
-                            .build()).toList();
-            ProductItemsResponse response = ProductItemsResponse.newBuilder().addAllProducts(products).build();
+            List<Product> products = productRepository.findByIdInAndIsDeletedFalse(new HashSet<>(request.getIdsList()));
+            if (products.isEmpty())
+                throw new ProductException(PRODUCT_NOT_FOUND);
+            CompletableFuture.runAsync(() -> productItemResponseGlobalCacheRepository.putAll(products));
+            List<ProductItemResponse> productItemResponses = products.stream().map(product -> ProductItemResponse.newBuilder()
+                    .setId(product.getId())
+                    .setBrandId(product.getProductBrand().getId())
+                    .setName(product.getName())
+                    .setThumbnail(product.getThumbnailPath())
+                    .setDiscount(product.getDiscount())
+                    .setPrice(product.getPrice())
+                    .setDiscountedPrice(product.getDiscountedPrice())
+                    .setBrandName(product.getProductBrand().getName())
+                    .setQuantity(product.getQuantity())
+                    .setOrderingOpensAt(product.getOrderingOpensAt().toString())
+                    .build()).toList();
+            ProductItemsResponse response = ProductItemsResponse.newBuilder().addAllProducts(productItemResponses).build();
             responseObserver.onNext(response);
             responseObserver.onCompleted();
 

--- a/product/src/main/proto/product.proto
+++ b/product/src/main/proto/product.proto
@@ -22,6 +22,7 @@ message ProductItemResponse {
   int32 price = 7;
   int32 discountedPrice = 8;
   string orderingOpensAt = 9;
+  int32 quantity = 10;
 }
 
 message ProductItemsRequest {

--- a/product/src/test/java/cm/twentysix/product/service/ProductStockServiceTest.java
+++ b/product/src/test/java/cm/twentysix/product/service/ProductStockServiceTest.java
@@ -1,10 +1,11 @@
 package cm.twentysix.product.service;
 
+import cm.twentysix.product.cache.ProductItemResponseGlobalCacheRepository;
 import cm.twentysix.product.domain.model.Product;
 import cm.twentysix.product.domain.model.ProductBrand;
 import cm.twentysix.product.domain.repository.ProductRepository;
-import cm.twentysix.product.dto.StockCheckFailedEvent;
 import cm.twentysix.product.dto.ProductStockResponse;
+import cm.twentysix.product.dto.StockCheckFailedEvent;
 import cm.twentysix.product.exception.Error;
 import cm.twentysix.product.exception.ProductException;
 import cm.twentysix.product.messaging.MessageSender;
@@ -30,6 +31,8 @@ import static org.mockito.Mockito.*;
 class ProductStockServiceTest {
     @Mock
     private ProductRepository productRepository;
+    @Mock
+    private ProductItemResponseGlobalCacheRepository productItemResponseGlobalCacheRepository;
     @Mock
     private MessageSender messageSender;
     @InjectMocks


### PR DESCRIPTION
## 🔎 PR Description
- Close #65 
> Apply Global Caching to ProductItemResponse

## 🔑 Key Changes
- Use Redis as a global cache to cache ProductItemResponse.
- Perform stock checks during order placement by querying the cache.

## 📢 To Reviewers
