### PR TITLE
switch Redis operations from put to increment for improved efficiency and atomicity

### DIFF
--- a/order/src/main/java/cm/twentysix/order/cache/global/GlobalCacheRepository.java
+++ b/order/src/main/java/cm/twentysix/order/cache/global/GlobalCacheRepository.java
@@ -3,6 +3,7 @@ package cm.twentysix.order.cache.global;
 import cm.twentysix.order.client.RedisClient;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,5 +59,12 @@ public abstract class GlobalCacheRepository<T, V extends T> {
                         .collect(Collectors.toMap(
                                 entry -> getCacheKey(entry.getKey()), Map.Entry::getValue));
         redisClient.addValues(cacheKeyValue, getCacheDuration());
+    }
+
+    public void putAllIfAbsent(Map<String, V> keyValueMap){
+        Map<String, T> cacheKeyValue = keyValueMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> getCacheKey(entry.getKey()), Map.Entry::getValue));
+        redisClient.addValuesIfAbsent(cacheKeyValue, getCacheDuration());
     }
 }

--- a/order/src/main/java/cm/twentysix/order/client/RedisClient.java
+++ b/order/src/main/java/cm/twentysix/order/client/RedisClient.java
@@ -47,4 +47,18 @@ public class RedisClient<T> {
     public void addValue(String key, T value, Duration duration) {
         redisTemplate.opsForValue().set(key, value, duration);
     }
+
+    public void decrementValuesBy(Map<String, Integer> keyDelta){
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            keyDelta.forEach((k, v) -> redisTemplate.opsForValue().decrement(k,v));
+            return null;
+        });
+    }
+
+    public void incrementValuesBy(Map<String, Integer> keyDelta){
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            keyDelta.forEach((k, v) -> redisTemplate.opsForValue().increment(k,v));
+            return null;
+        });
+    }
 }

--- a/order/src/main/java/cm/twentysix/order/domain/model/Order.java
+++ b/order/src/main/java/cm/twentysix/order/domain/model/Order.java
@@ -144,4 +144,11 @@ public class Order extends BaseTimeEntity {
     public boolean isReturnAllowed() {
         return OrderStatus.DELIVERED.equals(status) && LocalDateTime.now().isBefore(updatedAt.plusDays(1));
     }
+
+    public Map<String, Integer> getProductIdQuantityMap() {
+        return getProducts().entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().getQuantity()
+        ));
+    }
 }

--- a/order/src/main/java/cm/twentysix/order/dto/OrderCancelledEvent.java
+++ b/order/src/main/java/cm/twentysix/order/dto/OrderCancelledEvent.java
@@ -13,10 +13,7 @@ public record OrderCancelledEvent(
 ) {
     public static OrderCancelledEvent from(Order order) {
         return OrderCancelledEvent.builder()
-                .productQuantity(order.getProducts().entrySet().stream().collect(Collectors.toMap(
-                        idProductEntry -> idProductEntry.getKey(),
-                        idProductEntry -> idProductEntry.getValue().getQuantity()
-                )))
+                .productQuantity(order.getProductIdQuantityMap())
                 .orderId(order.getOrderId())
                 .build();
     }

--- a/order/src/main/java/cm/twentysix/order/dto/OrderFailedEvent.java
+++ b/order/src/main/java/cm/twentysix/order/dto/OrderFailedEvent.java
@@ -13,10 +13,7 @@ public record OrderFailedEvent(
 ) {
     public static OrderFailedEvent from(Order order) {
         return OrderFailedEvent.builder()
-                .productQuantity(order.getProducts().entrySet().stream().collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        idProductEntry -> idProductEntry.getValue().getQuantity()
-                )))
+                .productQuantity(order.getProductIdQuantityMap())
                 .orderId(order.getOrderId())
                 .build();
     }

--- a/payment/src/main/java/cm/twentysix/payment/exception/Error.java
+++ b/payment/src/main/java/cm/twentysix/payment/exception/Error.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum Error {
     INVALID_CONCURRENT_ACCESS(HttpStatus.BAD_REQUEST, "Concurrent access not allowed"),
     CANCELLED_ORDER(HttpStatus.BAD_REQUEST, "Cancelled order"),
+    BLOCKED_ORDER(HttpStatus.BAD_REQUEST, "Blocked order"),
     ALREADY_PAID_ORDER(HttpStatus.BAD_REQUEST, "Already paid order"),
     PAYMENT_FAILED(HttpStatus.PRECONDITION_FAILED, "Payment failed"),
     NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "해당하는 결제 건이 없습니다."),

--- a/payment/src/main/java/cm/twentysix/payment/handler/PaymentEventHandler.java
+++ b/payment/src/main/java/cm/twentysix/payment/handler/PaymentEventHandler.java
@@ -45,7 +45,5 @@ public class PaymentEventHandler {
                 .orElseThrow(() -> new PaymentException(Error.NOT_FOUND_PAYMENT));
 
         payment.block();
-        if(event.shouldNotifyFailed())
-            messageSender.sendPaymentFinalizedEvent(PaymentFinalizedEvent.of(event.orderId(), false));
     }
 }

--- a/payment/src/test/java/cm/twentysix/payment/service/PaymentServiceTest.java
+++ b/payment/src/test/java/cm/twentysix/payment/service/PaymentServiceTest.java
@@ -168,6 +168,66 @@ class PaymentServiceTest {
     }
 
     @Test
+    void confirm_fail_BLOCKED_ORDER() {
+        //given
+        PaymentForm form = new PaymentForm("any-order-id", "10000", "any-payment-key");
+        Payment payment = Payment.builder()
+                .amount(10000)
+                .orderName("any-order-name")
+                .userId(1L)
+                .orderId("any-order-id")
+                .productQuantity(Map.of("123", 1))
+                .status(PaymentStatus.BLOCK)
+                .build();
+        given(paymentRepository.findByOrderId(anyString()))
+                .willReturn(Optional.of(payment));
+        //when
+        PaymentException e = assertThrows(PaymentException.class, () -> paymentService.confirm(form));
+        //then
+        assertEquals(e.getError(), Error.BLOCKED_ORDER);
+    }
+
+    @Test
+    void confirm_fail_CANCELLED_ORDER() {
+        //given
+        PaymentForm form = new PaymentForm("any-order-id", "10000", "any-payment-key");
+        Payment payment = Payment.builder()
+                .amount(10000)
+                .orderName("any-order-name")
+                .userId(1L)
+                .orderId("any-order-id")
+                .productQuantity(Map.of("123", 1))
+                .status(PaymentStatus.CANCEL)
+                .build();
+        given(paymentRepository.findByOrderId(anyString()))
+                .willReturn(Optional.of(payment));
+        //when
+        PaymentException e = assertThrows(PaymentException.class, () -> paymentService.confirm(form));
+        //then
+        assertEquals(e.getError(), Error.CANCELLED_ORDER);
+    }
+
+    @Test
+    void confirm_fail_ALREADY_PAID_ORDER() {
+        //given
+        PaymentForm form = new PaymentForm("any-order-id", "10000", "any-payment-key");
+        Payment payment = Payment.builder()
+                .amount(10000)
+                .orderName("any-order-name")
+                .userId(1L)
+                .orderId("any-order-id")
+                .productQuantity(Map.of("123", 1))
+                .status(PaymentStatus.COMPLETE)
+                .build();
+        given(paymentRepository.findByOrderId(anyString()))
+                .willReturn(Optional.of(payment));
+        //when
+        PaymentException e = assertThrows(PaymentException.class, () -> paymentService.confirm(form));
+        //then
+        assertEquals(e.getError(), Error.ALREADY_PAID_ORDER);
+    }
+
+    @Test
     void confirm_fail_STOCK_SHORTAGE() {
         //given
         PaymentForm form = new PaymentForm("any-order-id", "10000", "any-payment-key");


### PR DESCRIPTION
## 🔎 PR Description
- Close #89 
> To enhance performance and ensure atomic operations, should replace the current put method with the increment operation in our Redis implementation. This change will leverage Redis's native atomic increment feature, reducing potential race conditions and improving overall efficiency.
This modification will ensure that our Redis operations are more efficient and thread-safe.

## 🔑 Key Changes
-  Switch Redis operations from put to increment for improved efficiency and atomicity

## 📢 To Reviewers
