### PR TITLE
exclude feign-client component in web mvc test

### DIFF
--- a/user/src/test/java/cm/twentysix/user/controller/AddressControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/AddressControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -25,7 +27,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = AddressController.class)
+@WebMvcTest(controllers = AddressController.class, excludeFilters = @ComponentScan.Filter(FeignClient.class))
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 class AddressControllerTest {

--- a/user/src/test/java/cm/twentysix/user/controller/EmailAuthControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/EmailAuthControllerTest.java
@@ -14,6 +14,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = EmailAuthController.class)
+@WebMvcTest(controllers = EmailAuthController.class, excludeFilters = @ComponentScan.Filter(FeignClient.class))
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 class EmailAuthControllerTest {

--- a/user/src/test/java/cm/twentysix/user/controller/LogInControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/LogInControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -28,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = LogInController.class)
+@WebMvcTest(controllers = LogInController.class, excludeFilters = @ComponentScan.Filter(FeignClient.class))
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 class LogInControllerTest {

--- a/user/src/test/java/cm/twentysix/user/controller/LogOutControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/LogOutControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,7 +26,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = LogOutController.class)
+@WebMvcTest(controllers = LogOutController.class, excludeFilters = @ComponentScan.Filter(FeignClient.class))
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 class LogOutControllerTest {

--- a/user/src/test/java/cm/twentysix/user/controller/SignUpControllerTest.java
+++ b/user/src/test/java/cm/twentysix/user/controller/SignUpControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = SignUpController.class)
+@WebMvcTest(controllers = SignUpController.class, excludeFilters = @ComponentScan.Filter(FeignClient.class))
 @AutoConfigureMockMvc(addFilters = false)
 @AutoConfigureRestDocs
 class SignUpControllerTest {


### PR DESCRIPTION
## 🔎 PR Description
- Close #96 
> exclude feign-client component in web mvc test

## 🔑 Key Changes
- exclude feign-client component in web mvc test

## 📢 To Reviewers
